### PR TITLE
use %w verb in fmt.Errorf statements

### DIFF
--- a/internal/detector/application_lister.go
+++ b/internal/detector/application_lister.go
@@ -86,7 +86,7 @@ func parseEnvVars(environ []string) (map[string]string, error) {
 func extractClasspathsFromEnv(environ []string) ([]string, error) {
 	envVars, err := parseEnvVars(environ)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse environment variables: %s", err)
+		return nil, fmt.Errorf("unable to parse environment variables: %w", err)
 	}
 
 	jars := make([]string, 0)
@@ -103,7 +103,7 @@ func extractClasspathsFromProcess(cmdlineSlice []string, environ []string) ([]st
 	jarRepository := make(map[string]struct{})
 	agentJars, err := extractAgent(cmdlineSlice)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse javaagent from command line: %s", err)
+		return nil, fmt.Errorf("unable to parse javaagent from command line: %w", err)
 	}
 	for _, jar := range agentJars {
 		jarRepository[jar] = struct{}{}
@@ -112,7 +112,7 @@ func extractClasspathsFromProcess(cmdlineSlice []string, environ []string) ([]st
 	// Some jars or directories are referenced in command line flags
 	cmdClasspaths, err := extractOptionArgs(cmdlineSlice, []string{"-jar", "-cp", "-classpath"})
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse classpath from command line: %s", err)
+		return nil, fmt.Errorf("unable to parse classpath from command line: %w", err)
 	}
 
 	for _, cmdClasspath := range cmdClasspaths {
@@ -124,7 +124,7 @@ func extractClasspathsFromProcess(cmdlineSlice []string, environ []string) ([]st
 
 	envClasspaths, err := extractClasspathsFromEnv(environ)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse classpath from env variables: %s", err)
+		return nil, fmt.Errorf("unable to parse classpath from env variables: %w", err)
 	}
 
 	for _, envCp := range envClasspaths {
@@ -165,7 +165,7 @@ func expandJarPaths(cwd string, paths []string) ([]string, error) {
 
 		isDir, err := isDirectory(absPath)
 		if err != nil {
-			return nil, fmt.Errorf("unable to determine if %s is a directory: %s", absPath, err)
+			return nil, fmt.Errorf("unable to determine if %s is a directory: %w", absPath, err)
 		}
 
 		if isDir {

--- a/internal/detector/elasticsearch_reporter.go
+++ b/internal/detector/elasticsearch_reporter.go
@@ -65,7 +65,7 @@ func (esr *ElasticSearchReporter) indexAssessment(assessment map[string]interfac
 func (esr *ElasticSearchReporter) Report(hostAssessment HostAssessment) error {
 	err := esr.indexAssessment(hostAssessment.ToReport())
 	if err != nil {
-		return fmt.Errorf("unable to index host assessment: %s", err)
+		return fmt.Errorf("unable to index host assessment: %w", err)
 	}
 
 	for _, appAssessment := range hostAssessment.ApplicationAssessments {
@@ -76,7 +76,7 @@ func (esr *ElasticSearchReporter) Report(hostAssessment HostAssessment) error {
 		doc["fqdn"] = hostAssessment.FQDN
 		err := esr.indexAssessment(doc)
 		if err != nil {
-			return fmt.Errorf("unable to index application assessment: %s", err)
+			return fmt.Errorf("unable to index application assessment: %w", err)
 		}
 	}
 
@@ -85,7 +85,7 @@ func (esr *ElasticSearchReporter) Report(hostAssessment HostAssessment) error {
 		doc["fqdn"] = hostAssessment.FQDN
 		err := esr.indexAssessment(doc)
 		if err != nil {
-			return fmt.Errorf("unable to index application assessment error: %s", err)
+			return fmt.Errorf("unable to index application assessment error: %w", err)
 		}
 	}
 

--- a/internal/detector/jar_assessor.go
+++ b/internal/detector/jar_assessor.go
@@ -60,7 +60,7 @@ func (ja *JarAssessor) Assess(path string) (JarAssessement, error) {
 	read, err := zip.OpenReader(path)
 
 	if err != nil {
-		return JarAssessement{}, fmt.Errorf("unable to open zip file %s: %s", path, err)
+		return JarAssessement{}, fmt.Errorf("unable to open zip file %s: %w", path, err)
 	}
 	defer read.Close()
 
@@ -79,7 +79,7 @@ func (ja *JarAssessor) Assess(path string) (JarAssessement, error) {
 
 		freader, err := file.Open()
 		if err != nil {
-			return JarAssessement{}, fmt.Errorf("unable to open pom.properties from %s: %s", path, err)
+			return JarAssessement{}, fmt.Errorf("unable to open pom.properties from %s: %w", path, err)
 		}
 		defer freader.Close()
 


### PR DESCRIPTION
this verb does not work with logrus.Errorf though, it generates the following
error: "Errorf call has error-wrapping directive %w, which is only
supported by Errorf"