### PR TITLE
consider all versions up to 2.16 to be vulnerable

### DIFF
--- a/internal/detector/jar_assessment.go
+++ b/internal/detector/jar_assessment.go
@@ -9,9 +9,7 @@ type JarAssessement struct {
 func (ja JarAssessement) IsVulnerable() bool {
 	if ja.Log4jVersion.Major < 2 {
 		return false
-	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor == 0 {
-		return false
-	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 16 {
+	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 17 {
 		return false
 	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 1 && !ja.isJNDIClassIncluded {
 		return false

--- a/internal/detector/jar_assessment_test.go
+++ b/internal/detector/jar_assessment_test.go
@@ -15,12 +15,12 @@ func TestJarAssessmentIsVulnerable(t *testing.T) {
 	}{
 		{false, Semver{1, 0, 0}, false},
 		{true, Semver{1, 0, 0}, false},
-		{false, Semver{2, 0, 0}, false},
-		{true, Semver{2, 0, 0}, false},
+		{false, Semver{2, 0, 0}, true},
+		{true, Semver{2, 0, 0}, true},
 		{true, Semver{2, 2, 0}, true},
 		{false, Semver{2, 2, 0}, false},
-		{false, Semver{2, 16, 0}, false},
-		{true, Semver{2, 16, 0}, false},
+		{false, Semver{2, 17, 0}, false},
+		{true, Semver{2, 17, 0}, false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Advisory: https://logging.apache.org/log4j/2.x/security.html