### PR TITLE
fix detection on windows

### DIFF
--- a/internal/detector/application_lister.go
+++ b/internal/detector/application_lister.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/shirou/gopsutil/process"
@@ -67,7 +68,14 @@ func extractOptionArgs(cmdlineSlice []string, flags []string) ([]string, error) 
 }
 
 func parseClassPathWithSeparators(classpath string) []string {
-	return strings.Split(classpath, ";")
+	var separator string
+	switch runtime.GOOS {
+	case "windows":
+		separator = ";"
+	default:
+		separator = ":"
+	}
+	return strings.Split(classpath, separator)
 }
 
 func parseEnvVars(environ []string) (map[string]string, error) {

--- a/internal/detector/application_lister.go
+++ b/internal/detector/application_lister.go
@@ -54,7 +54,9 @@ func extractOptionArgs(cmdlineSlice []string, flags []string) ([]string, error) 
 		if len(cmdlineSlice) <= idx {
 			return nil, fmt.Errorf("unable to parse flag at position %d in %s", idx+1, strings.Join(cmdlineSlice, " "))
 		}
-		values[cmdlineSlice[idx]] = struct{}{}
+		// In Windows, quotes wrapping arguments are not trimmed by the OS as in Unix
+		flagValue := strings.Trim(cmdlineSlice[idx], "\"")
+		values[flagValue] = struct{}{}
 	}
 
 	out := make([]string, 0)
@@ -64,8 +66,8 @@ func extractOptionArgs(cmdlineSlice []string, flags []string) ([]string, error) 
 	return out, nil
 }
 
-func parseClassPath(classpath string) []string {
-	return strings.Split(classpath, ":")
+func parseClassPathWithSeparators(classpath string) []string {
+	return strings.Split(classpath, ";")
 }
 
 func parseEnvVars(environ []string) (map[string]string, error) {
@@ -90,11 +92,18 @@ func extractClasspathsFromEnv(environ []string) ([]string, error) {
 	}
 
 	jars := make([]string, 0)
+	classpathEnvDetected := false
 
 	for envKey, envValue := range envVars {
 		if strings.Contains(envKey, "CLASSPATH") {
-			jars = append(jars, parseClassPath(envValue)...)
+			logrus.Debugf("Classpath environment variable detected: %s=%s", envKey, envValue)
+			jars = append(jars, parseClassPathWithSeparators(envValue)...)
+			classpathEnvDetected = true
 		}
+	}
+
+	if !classpathEnvDetected {
+		logrus.Debugf("No classpath environment variable detected")
 	}
 	return jars, nil
 }
@@ -116,7 +125,7 @@ func extractClasspathsFromProcess(cmdlineSlice []string, environ []string) ([]st
 	}
 
 	for _, cmdClasspath := range cmdClasspaths {
-		jarPaths := parseClassPath(cmdClasspath)
+		jarPaths := parseClassPathWithSeparators(cmdClasspath)
 		for _, jar := range jarPaths {
 			jarRepository[jar] = struct{}{}
 		}

--- a/internal/detector/application_lister_test.go
+++ b/internal/detector/application_lister_test.go
@@ -135,8 +135,10 @@ func TestExtractJarsFromProcess(t *testing.T) {
 	classpaths, err := extractClasspathsFromProcess(args, []string{
 		"TEST=myvar",
 		"CLASSPATH=cp.jar",
-		"USER_CLASSPATH=user.jar:/usr/lib/*",
+		"USER_CLASSPATH=user.jar;/usr/lib/*",
 		"USER_CLASSPATH_TEST=user2.jar",
+		// The separator between jars in the classpath is ;
+		"SEPARATED_CLASSPATH=separated1.jar;separated2.jar",
 	})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, classpaths, []string{
@@ -147,7 +149,21 @@ func TestExtractJarsFromProcess(t *testing.T) {
 		"user.jar",
 		"user2.jar",
 		"/usr/lib/*",
+		"separated1.jar",
+		"separated2.jar",
 	})
+}
+
+// This test more specifically targets Windows
+func TestExtractJarsFromProcessQuotesNotTrimmedByOS(t *testing.T) {
+	args := []string{
+		"java",
+		"-jar",
+		"\"C:\\test.jar\"",
+	}
+	classpaths, err := extractClasspathsFromProcess(args, []string{})
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, classpaths, []string{"C:\\test.jar"})
 }
 
 func TestExpandJarPaths(t *testing.T) {

--- a/internal/detector/application_lister_test.go
+++ b/internal/detector/application_lister_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,10 +136,10 @@ func TestExtractJarsFromProcess(t *testing.T) {
 	classpaths, err := extractClasspathsFromProcess(args, []string{
 		"TEST=myvar",
 		"CLASSPATH=cp.jar",
-		"USER_CLASSPATH=user.jar;/usr/lib/*",
+		"USER_CLASSPATH=user.jar:/usr/lib/*",
 		"USER_CLASSPATH_TEST=user2.jar",
 		// The separator between jars in the classpath is ;
-		"SEPARATED_CLASSPATH=separated1.jar;separated2.jar",
+		"SEPARATED_CLASSPATH=separated1.jar:separated2.jar",
 	})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, classpaths, []string{
@@ -156,6 +157,9 @@ func TestExtractJarsFromProcess(t *testing.T) {
 
 // This test more specifically targets Windows
 func TestExtractJarsFromProcessQuotesNotTrimmedByOS(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("skipping test on platform other than windows")
+	}
 	args := []string{
 		"java",
 		"-jar",


### PR DESCRIPTION
there were two problems on Windows:
- command arguments are containing quotes and therefore some args were not considered as file paths
- the separator for the classpath was wrong