### PR TITLE
specify the safe version in command line

### DIFF
--- a/cmd/log4j-jndi-jar-detector/main.go
+++ b/cmd/log4j-jndi-jar-detector/main.go
@@ -14,6 +14,7 @@ var Reporters []string
 var Daemon bool
 var DaemonInterval time.Duration
 var Verbose bool
+var SafeVersion string
 
 var rootCmd = &cobra.Command{
 	Use:   "log4j-jndi-jar-detector",
@@ -24,7 +25,7 @@ var rootCmd = &cobra.Command{
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 
-		detector.RunDetection(Reporters, Daemon, DaemonInterval)
+		detector.RunDetection(Reporters, Daemon, DaemonInterval, SafeVersion)
 	},
 }
 
@@ -33,6 +34,7 @@ func main() {
 	rootCmd.Flags().BoolVarP(&Daemon, "daemon", "d", false, "enable/disable daemon mode")
 	rootCmd.Flags().DurationVarP(&DaemonInterval, "interval", "i", 15*time.Minute, "duration between intervals in daemon mode")
 	rootCmd.Flags().BoolVarP(&Verbose, "verbose", "", false, "enable verbose logs")
+	rootCmd.Flags().StringVarP(&SafeVersion, "safe-version", "", "2.16.0", "version from which we consider the library to be safe")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/detector/application_assessment.go
+++ b/internal/detector/application_assessment.go
@@ -12,16 +12,16 @@ type ApplicationAssessment struct {
 	JarAssessments []JarAssessement
 }
 
-func (aa *ApplicationAssessment) IsVulnerable() bool {
+func (aa *ApplicationAssessment) IsVulnerable(safeVersion Semver) bool {
 	for _, j := range aa.JarAssessments {
-		if j.IsVulnerable() {
+		if j.IsVulnerable(safeVersion) {
 			return true
 		}
 	}
 	return false
 }
 
-func (aa ApplicationAssessment) ToReport() map[string]interface{} {
+func (aa ApplicationAssessment) ToReport(safeVersion Semver) map[string]interface{} {
 	vulnJars := make([]string, 0)
 	hasJNDIClass := false
 	versionSet := map[Semver]struct{}{}
@@ -29,7 +29,7 @@ func (aa ApplicationAssessment) ToReport() map[string]interface{} {
 
 	for _, j := range aa.JarAssessments {
 		// skip non vulnerable assessments
-		if !j.IsVulnerable() {
+		if !j.IsVulnerable(safeVersion) {
 			continue
 		}
 		vulnerableAssessmentsCount += 1

--- a/internal/detector/application_assessment_test.go
+++ b/internal/detector/application_assessment_test.go
@@ -12,7 +12,7 @@ func TestApplicationAssessmentToReport(t *testing.T) {
 		JarAssessments: []JarAssessement{VulnerableJarAssessment, NonVulnerableJarAssessment},
 	}
 
-	report := applicationAssessment.ToReport()
+	report := applicationAssessment.ToReport(Semver{Major: 2, Minor: 17, Patch: 0})
 	assert.Equal(t, map[string]interface{}{
 		"appname":        "java -jar app.jar",
 		"has_jndi_class": true,

--- a/internal/detector/elasticsearch_reporter.go
+++ b/internal/detector/elasticsearch_reporter.go
@@ -87,18 +87,18 @@ func (esr *ElasticSearchReporter) indexAssessment(assessment map[string]interfac
 	return nil
 }
 
-func (esr *ElasticSearchReporter) ReportAssessment(hostAssessment HostAssessment) error {
+func (esr *ElasticSearchReporter) ReportAssessment(hostAssessment HostAssessment, safeVersion Semver) error {
 	logrus.Infof("reporting assessment to elasticsearch %s", esr.url)
-	err := esr.indexAssessment(hostAssessment.ToReport())
+	err := esr.indexAssessment(hostAssessment.ToReport(safeVersion))
 	if err != nil {
 		return fmt.Errorf("unable to index host assessment: %w", err)
 	}
 
 	for _, appAssessment := range hostAssessment.ApplicationAssessments {
-		if !appAssessment.IsVulnerable() {
+		if !appAssessment.IsVulnerable(safeVersion) {
 			continue
 		}
-		doc := appAssessment.ToReport()
+		doc := appAssessment.ToReport(safeVersion)
 		doc["fqdn"] = hostAssessment.FQDN
 		err := esr.indexAssessment(doc)
 		if err != nil {

--- a/internal/detector/host_assessment.go
+++ b/internal/detector/host_assessment.go
@@ -21,10 +21,10 @@ func NewHostAssessment(fqdn string, appAssessments []ApplicationAssessment,
 	}
 }
 
-func (ha HostAssessment) ToReport() map[string]interface{} {
+func (ha HostAssessment) ToReport(safeVersion Semver) map[string]interface{} {
 	vulnerableAppAssessments := []ApplicationAssessment{}
 	for _, appAssessment := range ha.ApplicationAssessments {
-		if appAssessment.IsVulnerable() {
+		if appAssessment.IsVulnerable(safeVersion) {
 			vulnerableAppAssessments = append(vulnerableAppAssessments, appAssessment)
 		}
 	}

--- a/internal/detector/host_assessment_test.go
+++ b/internal/detector/host_assessment_test.go
@@ -53,5 +53,5 @@ func TestHostAssessmentToReport(t *testing.T) {
 		"nb_vuln_java_processes": 1,
 		"run_end_time":           "2021-01-01T01:02:10Z",
 		"run_start_time":         "2021-01-01T01:00:00Z",
-	}, ha.ToReport())
+	}, ha.ToReport(Semver{Major: 2, Minor: 17, Patch: 0}))
 }

--- a/internal/detector/jar_assessment.go
+++ b/internal/detector/jar_assessment.go
@@ -6,12 +6,12 @@ type JarAssessement struct {
 	Log4jVersion        Semver
 }
 
-func (ja JarAssessement) IsVulnerable() bool {
+func (ja JarAssessement) IsVulnerable(safeVersion Semver) bool {
 	if ja.Log4jVersion.Major < 2 {
 		return false
-	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 17 {
-		return false
 	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 1 && !ja.isJNDIClassIncluded {
+		return false
+	} else if safeVersion.Less(ja.Log4jVersion) || safeVersion.Equal(ja.Log4jVersion) {
 		return false
 	}
 	return true

--- a/internal/detector/jar_assessment_test.go
+++ b/internal/detector/jar_assessment_test.go
@@ -30,7 +30,7 @@ func TestJarAssessmentIsVulnerable(t *testing.T) {
 				Path:                "/home/user/app.jar",
 				Log4jVersion:        tc.version,
 			}
-			assert.Equal(t, tc.vulnerable, ja.IsVulnerable())
+			assert.Equal(t, tc.vulnerable, ja.IsVulnerable(Semver{2, 17, 0}))
 		})
 	}
 }

--- a/internal/detector/jar_assessor_test.go
+++ b/internal/detector/jar_assessor_test.go
@@ -34,7 +34,7 @@ func TestJarAssessorOnVulnerableLog4j(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.JNDIClassIncluded, assessment.isJNDIClassIncluded)
 			assert.Equal(t, tc.Version, assessment.Log4jVersion)
-			assert.Equal(t, tc.IsVulnerable, assessment.IsVulnerable())
+			assert.Equal(t, tc.IsVulnerable, assessment.IsVulnerable(Semver{2, 17, 0}))
 		})
 	}
 }

--- a/internal/detector/reporter.go
+++ b/internal/detector/reporter.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Reporter interface {
-	ReportAssessment(hostAssessment HostAssessment) error
+	ReportAssessment(hostAssessment HostAssessment, safeVersion Semver) error
 	ReportError(fqdn string, anError error) error
 }
 
@@ -35,9 +35,9 @@ func NewReporterComposite(reporterArgs []string) (*ReporterComposite, error) {
 	return &reporterComposite, nil
 }
 
-func (rc *ReporterComposite) ReportAssessment(hostAssessment HostAssessment) error {
+func (rc *ReporterComposite) ReportAssessment(hostAssessment HostAssessment, safeVersion Semver) error {
 	for _, reporter := range rc.reporters {
-		err := reporter.ReportAssessment(hostAssessment)
+		err := reporter.ReportAssessment(hostAssessment, safeVersion)
 		if err != nil {
 			return err
 		}

--- a/internal/detector/reporter_mock.go
+++ b/internal/detector/reporter_mock.go
@@ -34,17 +34,17 @@ func (m *MockReporter) EXPECT() *MockReporterMockRecorder {
 }
 
 // ReportAssessment mocks base method.
-func (m *MockReporter) ReportAssessment(hostAssessment HostAssessment) error {
+func (m *MockReporter) ReportAssessment(hostAssessment HostAssessment, safeVersion Semver) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportAssessment", hostAssessment)
+	ret := m.ctrl.Call(m, "ReportAssessment", hostAssessment, safeVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportAssessment indicates an expected call of ReportAssessment.
-func (mr *MockReporterMockRecorder) ReportAssessment(hostAssessment interface{}) *gomock.Call {
+func (mr *MockReporterMockRecorder) ReportAssessment(hostAssessment, safeVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportAssessment", reflect.TypeOf((*MockReporter)(nil).ReportAssessment), hostAssessment)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportAssessment", reflect.TypeOf((*MockReporter)(nil).ReportAssessment), hostAssessment, safeVersion)
 }
 
 // ReportError mocks base method.

--- a/internal/detector/reporter_test.go
+++ b/internal/detector/reporter_test.go
@@ -23,10 +23,10 @@ func TestReportAssessment(t *testing.T) {
 	reporter.reporters["test"] = m
 
 	m.EXPECT().
-		ReportAssessment(gomock.Eq(assessment)).
+		ReportAssessment(gomock.Eq(assessment), gomock.Eq(Semver{Major: 2, Minor: 17, Patch: 0})).
 		Return(nil)
 
-	err = reporter.ReportAssessment(assessment)
+	err = reporter.ReportAssessment(assessment, Semver{Major: 2, Minor: 17, Patch: 0})
 	assert.NoError(t, err)
 }
 

--- a/internal/detector/semver.go
+++ b/internal/detector/semver.go
@@ -45,3 +45,18 @@ func ParseSemver(version string) (Semver, error) {
 
 	return Semver{Major: major, Minor: minor, Patch: patch}, nil
 }
+
+func (s Semver) Equal(other Semver) bool {
+	return s.Major == other.Major && s.Minor == other.Minor && s.Patch == other.Patch
+}
+
+func (s Semver) Less(other Semver) bool {
+	if s.Major == other.Major && s.Minor == other.Minor && s.Patch < other.Patch {
+		return true
+	} else if s.Major == other.Major && s.Minor < other.Minor {
+		return true
+	} else if s.Major < other.Major {
+		return true
+	}
+	return false
+}

--- a/internal/detector/semver_test.go
+++ b/internal/detector/semver_test.go
@@ -1,6 +1,7 @@
 package detector
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,4 +34,62 @@ func TestSemverParsing(t *testing.T) {
 
 func TestSemverToString(t *testing.T) {
 	assert.Equal(t, "1.2.3", Semver{Major: 1, Minor: 2, Patch: 3}.String())
+}
+
+func TestSemverEqual(t *testing.T) {
+	testCases := []struct {
+		s1    Semver
+		s2    Semver
+		equal bool
+	}{
+		{Semver{2, 17, 5}, Semver{2, 17, 4}, false},
+		{Semver{2, 17, 5}, Semver{2, 17, 5}, true},
+		{Semver{2, 17, 5}, Semver{2, 17, 6}, false},
+		{Semver{2, 17, 5}, Semver{2, 16, 5}, false},
+		{Semver{2, 17, 5}, Semver{2, 18, 5}, false},
+		{Semver{2, 17, 5}, Semver{1, 17, 5}, false},
+		{Semver{2, 17, 5}, Semver{3, 17, 5}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s < %s", tc.s1, tc.s2), func(t *testing.T) {
+			assert.Equal(t, tc.equal, tc.s1.Equal(tc.s2))
+		})
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	testCases := []struct {
+		s1   Semver
+		s2   Semver
+		less bool
+	}{
+		{Semver{2, 17, 5}, Semver{2, 17, 4}, false},
+		{Semver{2, 17, 5}, Semver{2, 17, 5}, false},
+		{Semver{2, 17, 5}, Semver{2, 17, 6}, true},
+
+		{Semver{2, 17, 5}, Semver{2, 16, 4}, false},
+		{Semver{2, 17, 5}, Semver{2, 16, 5}, false},
+		{Semver{2, 17, 5}, Semver{2, 16, 6}, false},
+
+		{Semver{2, 17, 5}, Semver{2, 18, 4}, true},
+		{Semver{2, 17, 5}, Semver{2, 18, 5}, true},
+		{Semver{2, 17, 5}, Semver{2, 18, 6}, true},
+
+		{Semver{2, 17, 5}, Semver{1, 16, 4}, false},
+		{Semver{2, 17, 5}, Semver{1, 16, 5}, false},
+		{Semver{2, 17, 5}, Semver{1, 16, 6}, false},
+		{Semver{2, 17, 5}, Semver{1, 17, 4}, false},
+		{Semver{2, 17, 5}, Semver{1, 17, 5}, false},
+		{Semver{2, 17, 5}, Semver{1, 17, 6}, false},
+		{Semver{2, 17, 5}, Semver{1, 18, 4}, false},
+		{Semver{2, 17, 5}, Semver{1, 18, 5}, false},
+		{Semver{2, 17, 5}, Semver{1, 18, 6}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s < %s", tc.s1, tc.s2), func(t *testing.T) {
+			assert.Equal(t, tc.less, tc.s1.Less(tc.s2))
+		})
+	}
 }

--- a/internal/detector/stdout_reporter.go
+++ b/internal/detector/stdout_reporter.go
@@ -4,10 +4,10 @@ import "github.com/sirupsen/logrus"
 
 type StdoutReporter struct{}
 
-func (sr *StdoutReporter) ReportAssessment(hostAssessment HostAssessment) error {
+func (sr *StdoutReporter) ReportAssessment(hostAssessment HostAssessment, safeVersion Semver) error {
 	for _, a := range hostAssessment.ApplicationAssessments {
 		for _, j := range a.JarAssessments {
-			if !j.IsVulnerable() {
+			if !j.IsVulnerable(safeVersion) {
 				continue
 			}
 			logrus.Infof("%s used in process %d is vulnerable (Version=%s, JNDIClassExists=%t)",


### PR DESCRIPTION
this allows to configure the vulnerability assessment without compiling
a new version of the binary.