### PR TITLE
report all log4j v1 to be vulnerable

### DIFF
--- a/internal/detector/host_assessment_test.go
+++ b/internal/detector/host_assessment_test.go
@@ -10,7 +10,7 @@ import (
 var NonVulnerableJarAssessment = JarAssessement{
 	isJNDIClassIncluded: false,
 	Path:                "/home/myuser/app.jar",
-	Log4jVersion:        Semver{Major: 1, Minor: 0, Patch: 0},
+	Log4jVersion:        Semver{Major: 2, Minor: 1, Patch: 0},
 }
 
 var VulnerableJarAssessment = JarAssessement{

--- a/internal/detector/jar_assessment.go
+++ b/internal/detector/jar_assessment.go
@@ -7,9 +7,7 @@ type JarAssessement struct {
 }
 
 func (ja JarAssessement) IsVulnerable(safeVersion Semver) bool {
-	if ja.Log4jVersion.Major < 2 {
-		return false
-	} else if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 1 && !ja.isJNDIClassIncluded {
+	if ja.Log4jVersion.Major == 2 && ja.Log4jVersion.Minor >= 1 && !ja.isJNDIClassIncluded {
 		return false
 	} else if safeVersion.Less(ja.Log4jVersion) || safeVersion.Equal(ja.Log4jVersion) {
 		return false

--- a/internal/detector/jar_assessment_test.go
+++ b/internal/detector/jar_assessment_test.go
@@ -13,8 +13,10 @@ func TestJarAssessmentIsVulnerable(t *testing.T) {
 		version    Semver
 		vulnerable bool
 	}{
-		{false, Semver{1, 0, 0}, false},
-		{true, Semver{1, 0, 0}, false},
+		{false, Semver{1, 0, 0}, true},
+		{true, Semver{1, 0, 0}, true},
+		{false, Semver{1, 2, 0}, true},
+		{true, Semver{1, 2, 0}, true},
 		{false, Semver{2, 0, 0}, true},
 		{true, Semver{2, 0, 0}, true},
 		{true, Semver{2, 2, 0}, true},


### PR DESCRIPTION
this covers for CVE-2022-23307 which has been disclosed on v1 recently
and which is critical.